### PR TITLE
Clean up Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,20 @@
-all: clean kernel boot image
+.PHONY: clean
 
-clean: 
-	rm -rf *.o
+all: image
 
-kernel:
+clean:
+	rm -f *.o kernel.iso
+
+kernel.o: kernel.c
 	gcc -m32 -fno-stack-protector -fno-builtin -c kernel.c -o kernel.o
+
+vga.o: vga.c
 	gcc -m32 -fno-stack-protector -fno-builtin -c vga.c -o vga.o
 
-boot:
+boot.o: boot.s
 	nasm -f elf32 boot.s -o boot.o
 
-image:
+image: kernel.o vga.o boot.o
 	ld -m elf_i386 -T linker.ld -o kernel boot.o kernel.o vga.o
 	mv kernel Express/boot/kernel
 	grub-mkrescue -o kernel.iso Express/
-	rm *.o


### PR DESCRIPTION
- Mark `clean` with .PHONY as recommended by GNU Make documentation.

- Explicitly specify dependencies of each compilation artifact, allowing for recompiling only as needed.

- Avoid calling `clean` on every build, since it is no longer needed with explicit compilation dependencies.